### PR TITLE
Support generate crds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.22"
+version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452e67b9c20c37fa79df53201dc03839651086ed9bbe92b3ca585ca9fdaa7d85"
+checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1954,6 +1954,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror",
  "tokio",
  "tracing",

--- a/operator-k8s/Cargo.toml
+++ b/operator-k8s/Cargo.toml
@@ -11,6 +11,11 @@ categories = ["operator"]
 keywords = ["kubernetes", "xline", "operator"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bin]]
+doc = false
+name = "crdgen"
+path = "src/crdgen.rs"
+
 [dependencies]
 anyhow = "1.0.71"
 async-trait = "0.1.68"
@@ -21,6 +26,7 @@ kube = { version = "0.83.0", features = ["runtime", "derive"] }
 schemars = "0.8.6"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.97"
+serde_yaml = "0.9.25"
 thiserror = "1.0.40"
 tokio = { version = "1.0", features = [
     "rt-multi-thread",

--- a/operator-k8s/src/crdgen.rs
+++ b/operator-k8s/src/crdgen.rs
@@ -1,0 +1,10 @@
+use anyhow::Result;
+use clap::Parser;
+use xline_operator::config::Config;
+use xline_operator::operator::Operator;
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    let config = Config::parse();
+    Operator::new(config).generate_crds()
+}

--- a/operator-k8s/src/operator.rs
+++ b/operator-k8s/src/operator.rs
@@ -15,6 +15,9 @@ use crate::controller::cluster::Controller as ClusterController;
 use crate::controller::{Context, Controller};
 use crate::crd::Cluster;
 
+use std::fs::File;
+use std::io::Write;
+
 /// wait crd to establish timeout
 const CRD_ESTABLISH_TIMEOUT: Duration = Duration::from_secs(20);
 
@@ -53,6 +56,19 @@ impl Operator {
             cluster_suffix: self.config.cluster_suffix.clone(),
         }));
         ClusterController::run(ctx, cluster_api).await;
+        Ok(())
+    }
+
+    /// Generate crds
+    ///
+    /// # Errors
+    ///
+    /// Return `Err` when run failed
+    #[inline]
+    pub fn generate_crds(&self) -> Result<()> {
+        let path = format!("{}_{}.yaml",&Cluster::api_resource().group,&Cluster::api_resource().kind.to_lowercase());
+        let mut file = File::create(path).unwrap();
+        writeln!(file, "{}",serde_yaml::to_string(&Cluster::crd()).unwrap()).unwrap();
         Ok(())
     }
 


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

Generate crds,  it can be used other case and other language, i supose major is golang.

In the future, this file need to released simultaneously with the operator if the crds have changed.



* what changes does this pull request make?

It's create a new binary to generate crds, and the second idea is move it  to build.rs. i can update it to build.rs if it's necessarily.

CI is failed but feature is ready for review.

Since I'm not a rust expert, feel free to comment.

```shell
lan@lan:$ cargo run --bin crdgen
...
     Running `target/debug/crdgen`
lan@lan:$ ls
CODE_OF_CONDUCT.md  Cargo.toml  LICENSE    build     operator-k8s         sidecar  tests  xlineoperator.xline.cloud_xlinecluster.yaml
```

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
