### PR TITLE
chore: update xline docker image

### DIFF
--- a/tests/e2e/cases/manifests/cluster.yaml
+++ b/tests/e2e/cases/manifests/cluster.yaml
@@ -3,6 +3,6 @@ kind: XlineCluster
 metadata:
   name: my-xline-cluster
 spec:
-  image: phoenix500526/xline:v0.6.1
+  image: ghcr.io/xline-kv/xline:v0.6.1
   imagePullPolicy: IfNotPresent
   replicas: 3

--- a/tests/e2e/testenv/testenv.sh
+++ b/tests/e2e/testenv/testenv.sh
@@ -16,7 +16,7 @@ function testenv::k8s::delete() {
 function testenv::k8s::load_images() {
   # xline image
   log::info "Loading images"
-  xline_image="phoenix500526/xline:v0.6.1"
+  xline_image="ghcr.io/xline-kv/xline:v0.6.1"
   docker pull "$xline_image" 2>/dev/null
   testenv::k8s::kind::load_image "$xline_image"
   # etcdctl image


### PR DESCRIPTION
Please briefly answer these questions:
update xline docker image from "phoenix500526/xline:v0.6.1" to "ghcr.io/xline-kv/xline:v0.6.1"
* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
